### PR TITLE
Fix for setting Response's content in constructor

### DIFF
--- a/src/Framework/Basic/Object/Response.php
+++ b/src/Framework/Basic/Object/Response.php
@@ -69,7 +69,7 @@ class Response
         if (is_object($content) && $object instanceof ResponseInterface) {
             $this->setObject($content);
         } else {
-            $this->content = (string) $content;
+            $this->setContent((string) $content);
         }
         
         $this->setContentType((is_null($contentType) ? self::CONTENT_TYPE_HTML : $contentType));


### PR DESCRIPTION
It fixes setting $this->empty flag in Response, when content is set via
__construct()

Otherwise even if I've set content in Response via __construct(), the "empty" flag remains true, which it shouldn't.